### PR TITLE
Russian translation

### DIFF
--- a/src/main/java/doublenegation/mods/compactores/CompactOreBlockItem.java
+++ b/src/main/java/doublenegation/mods/compactores/CompactOreBlockItem.java
@@ -5,6 +5,11 @@ import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.registries.GameData;
+
+import java.util.Map;
 
 public class CompactOreBlockItem extends BlockItem {
 
@@ -18,7 +23,25 @@ public class CompactOreBlockItem extends BlockItem {
 
     @Override
     public ITextComponent getDisplayName(ItemStack stack) {
-        return block.getNameTextComponent();
+        return DistExecutor.runForDist(() -> () -> {
+            // CLIENT
+            return block.getNameTextComponent();
+        }, () -> () -> {
+            // SERVER
+            // Block#getNameTextComponent() is not a thing on the dedicated server, so don't use it here.
+            // Language files apparently also aren't, so a TranslationTextComponent won't do much good either.
+            if(block instanceof CompactOreBlock) {
+                Map<Block, Item> blockItemMap = GameData.getBlockItemMap();
+                Block baseBlock = ((CompactOreBlock) block).baseBlock();
+                if(blockItemMap.containsKey(baseBlock)) {
+                    ITextComponent baseName = blockItemMap.get(baseBlock).getDisplayName(stack);
+                    StringTextComponent name = new StringTextComponent("Compact ");
+                    name.appendSibling(baseName);
+                    return name;
+                }
+            }
+            return new StringTextComponent("Compact Ore");
+        });
     }
 
     @Override


### PR DESCRIPTION
{
  "block.compactores.compact_ore": "Плотная %s",
  "block.compactores.missing_ore": "Отсутствующая руда - несовпадение конфигурации!",
  "itemGroup.compactores": "Compact Ores",

  "gui.compactores.configupdate.title": "Обновление конфига Compact Ores",
  "gui.compactores.configupdate.message": "Compact Ores был успешно обновлён до версии %s!\n\nОднако, активная конфигурация была сделана в версии %s. Это означает, что конфигурация может вести себя не так, как предполагалось, из-за изменений в моде. Если вы используете конфигурацию по умолчанию, рекомендуется использовать функцию автоматического обновления ниже. Если вы используете пользовательскую конфигурацию, пожалуйста, обновите мод вручную (при необходимости).\n\nПредупреждение: Если вы используете функцию автоматического обновления, все изменения, внесенные в конфигурацию, будут УТЕРЯНЫ.\n\nВы хотите обновить конфигурацию мода (требуется перезапуск игры)?",
  "gui.compactores.configupdate.confirm": "Обновить и выйти из игры",
  "gui.compactores.configupdate.deny": "Оставить прежнюю версию",

  "gui.compactores.configloadfailure.title": "Ошибка загрузки конфига Compact Ores",
  "gui.compactores.configloadfailure.message": "Compact Ores не удалось правильно загрузить, так как при загрузке конфигурации произошла следующая ошибка:\n\n%s\n\nПожалуйста, исправьте ошибку для использования Compact Ores. Вы также можете сбросить конфигурацию до конфигурации по умолчанию, чтобы попытаться избежать ошибки, но это приведет к УДАЛЕНИЮ ВСЕХ ИЗМЕНЕНИЙ, внесенных в конфигурацию.",
  "gui.compactores.configloadfailure.deny": "Выйти из игры",
  "gui.compactores.configloadfailure.confirm": "Сбросить конфигурацию и выйти из игры",

  "chat.compactores.desync_warning": "§4§kiI|!'§r §6ПРЕДУПРЕЖДЕНИЕ COMPACT ORES:§r Compact ores конфигурация этого сервера не соответствует конфигурации на стороне клиента. Это приведет к странному поведению и различным проблемам. Пожалуйста, синхронизируйте свою конфигурацию с конфигурацией сервера для получения наилучшего опыта. §4§kiI|!'§r"
}